### PR TITLE
Added support for engineio

### DIFF
--- a/gevent_ws/__init__.py
+++ b/gevent_ws/__init__.py
@@ -259,3 +259,10 @@ class WebSocketHandler(WSGIHandler):
     def process_result(self):
         if "wsgi.websocket" not in self.environ:
             super(WebSocketHandler, self).process_result()
+
+    @property
+    def version(self):
+        if not self.environ:
+            return
+
+        return self.environ.get('HTTP_SEC_WEBSOCKET_VERSION')

--- a/gevent_ws/__init__.py
+++ b/gevent_ws/__init__.py
@@ -263,6 +263,6 @@ class WebSocketHandler(WSGIHandler):
     @property
     def version(self):
         if not self.environ:
-            return
+            return None
 
         return self.environ.get('HTTP_SEC_WEBSOCKET_VERSION')


### PR DESCRIPTION
I'm using [socketio](https://pypi.org/project/python-socketio) but it doesn't work. This is the traceback:

> Traceback (most recent call last):
>   File "/Users/menudoproblema/env/lib/python3.7/site-packages/gevent_ws/__init__.py", line 230, in handle_one_response
>     self.run_application()
>   File "/Users/menudoproblema/env/lib/python3.7/site-packages/gevent/pywsgi.py", line 923, in run_application
>     self.result = self.application(self.environ, self.start_response)
>   File "/Users/menudoproblema/env/lib/python3.7/site-packages/engineio/middleware.py", line 60, in __call__
>     return self.engineio_app.handle_request(environ, start_response)
>   File "/Users/menudoproblema/env/lib/python3.7/site-packages/socketio/server.py", line 555, in handle_request
>     return self.eio.handle_request(environ, start_response)
>   File "/Users/menudoproblema/env/lib/python3.7/site-packages/engineio/server.py", line 377, in handle_request
>     environ, start_response)
>   File "/Users/menudoproblema/env/lib/python3.7/site-packages/engineio/socket.py", line 108, in handle_get_request
>     start_response)
>   File "/Users/menudoproblema/env/lib/python3.7/site-packages/engineio/socket.py", line 152, in _upgrade_websocket
>     return ws(environ, start_response)
>   File "/Users/menudoproblema/env/lib/python3.7/site-packages/engineio/async_drivers/gevent.py", line 40, in __call__
>     self.version = self._sock.version
> AttributeError: 'WebSocket' object has no attribute 'version'
